### PR TITLE
Changed note about official driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ArangoDB client
 ===============
 A client for the ArangoDB nosql database for nodejs and browsers.
 
-NOTE: This repo is now officially maintained by the developers of ArangoDB @ https://github.com/triAGENS/ArangoDB-JavaScript. 
+NOTE: The official ArangoDB JavaScript driver now lives @ https://github.com/arangodb/arangojs. 
 
 ### Latest changes
 The Query API returns result from Aql cursors unfiltered.


### PR DESCRIPTION
The note about the official driver currently points to a fork of this repo that is no longer maintained. The official ArangoDB JS driver has since been re-implemented from scratch and lives at a different URL.

To [avoid confusion](https://github.com/arangodb/arangodb/issues/1357) I've reworded the line in the README and updated the URL.